### PR TITLE
Fix docs regarding messages.get (options.receivedAfter)

### DIFF
--- a/lib/operations/messages.js
+++ b/lib/operations/messages.js
@@ -38,7 +38,7 @@ class Messages {
    * result (in milliseconds).
    *
    * @param {date} [options.receivedAfter] Limits results to only messages
-   * received after this date/time (default 20 seconds ago).
+   * received after this date/time (default 1 hour ago).
    *
    * @param {function} [optionalCallback] - The optional callback.
    *


### PR DESCRIPTION
In [official docs](https://mailosaur.com/docs/languages/nodejs/#library-reference) and [in the implementation](https://github.com/mailosaur/mailosaur-node/blob/5ff5c6a099cf04780b058575034a79b9f7288d1a/lib/operations/messages.js#L73), seems that the `messages.get` `options.receivedAfter` argument defaults to an hour, however docs specify 20 seconds.

This updates the JS documentation in that regard.