### PR TITLE
Provide more detailed info when the email search fails due to a timeout

### DIFF
--- a/lib/operations/messages.js
+++ b/lib/operations/messages.js
@@ -146,7 +146,7 @@ class Messages {
           if (((Date.now() - startTime) + delay) > options.timeout) {
             return (options.errorOnTimeout === false) ?
               resolve(body) :
-              reject(new MailosaurError('No matching messages found in time. By default, only messages received in the last hour are checked (use receivedAfter to override this).', 'search_timeout'));
+              reject(new MailosaurError(`No matching messages found in time. By default, only messages received in the last hour are checked (use receivedAfter to override this). The search criteria used for this query was [${JSON.stringify(criteria)}]`, 'search_timeout'));
           }
 
           return setTimeout(fn(resolve, reject), delay);

--- a/lib/operations/messages.js
+++ b/lib/operations/messages.js
@@ -146,7 +146,7 @@ class Messages {
           if (((Date.now() - startTime) + delay) > options.timeout) {
             return (options.errorOnTimeout === false) ?
               resolve(body) :
-              reject(new MailosaurError(`No matching messages found in time. By default, only messages received in the last hour are checked (use receivedAfter to override this). The search criteria used for this query was [${JSON.stringify(criteria)}]`, 'search_timeout'));
+              reject(new MailosaurError(`No matching messages found in time. By default, only messages received in the last hour are checked (use receivedAfter to override this). The search criteria used for this query was [${JSON.stringify(criteria)}] which timed out after ${options.timeout}ms`, 'search_timeout'));
           }
 
           return setTimeout(fn(resolve, reject), delay);

--- a/test/emails.js
+++ b/test/emails.js
@@ -202,6 +202,21 @@ describe('emails', () => {
         });
     });
 
+    it('should throw a meaningful error if the timeout is reached', (done) => {
+      const testFromEmail = 'zzyy@test.com';
+      client.messages
+        .search(server, {
+          sentFrom: testFromEmail
+        }, {
+          timeout: 1,
+        })
+        .catch((err) => {
+          assert.instanceOf(err, MailosaurError);
+          assert.equal(err.message, `No matching messages found in time. By default, only messages received in the last hour are checked (use receivedAfter to override this). The search criteria used for this query was [{"sentFrom":"${testFromEmail}"}] which timed out after 1ms`);
+          done();
+        });
+    });
+
     it('should return empty array if errors suppressed', (done) => {
       client.messages.search(server, {
         sentTo: 'neverfound@example.com'


### PR DESCRIPTION
This will update the error message thrown by the mail search from

`No matching messages found in time. By default, only messages received in the last hour are checked (use receivedAfter to override this).`

To

`No matching messages found in time. By default, only messages received in the last hour are checked (use receivedAfter to override this). The search criteria used for this query was {THE_SEARCH_CRITERIA} which timed out after {TIMEOUT}ms`