### PR TITLE
added fallback for missing search in URLs

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -75,7 +75,7 @@ class Request {
     const spread = Object.assign({}, options, {
       protocol: urlResult.protocol,
       hostname: urlResult.hostname,
-      path: urlResult.pathname + urlResult.search
+      path: urlResult.pathname + (urlResult.search || '')
     });
     const req = https.request(spread, (res) => {
       const data = [];


### PR DESCRIPTION
when building URLs in some contexts (like Cypress), the `search` property is null, which gets tacked on as the string `"null"` to the path.