### PR TITLE
Docs: README updates — inbox (server) terminology and dashboard links

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const mailosaur = new MailosaurClient()
 This library is powered by the Mailosaur [email & SMS testing API](https://mailosaur.com/docs/api/). You can easily check out the API itself by looking at our [API reference documentation](https://mailosaur.com/docs/api/) or via our Postman or Insomnia collections:
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/6961255-6cc72dff-f576-451a-9023-b82dec84f95d?action=collection%2Ffork&collection-url=entityId%3D6961255-6cc72dff-f576-451a-9023-b82dec84f95d%26entityType%3Dcollection%26workspaceId%3D386a4af1-4293-4197-8f40-0eb49f831325)
- [![Run in Insomnia}](https://insomnia.rest/images/run.svg)](https://insomnia.rest/run/?label=Mailosaur&uri=https%3A%2F%2Fmailosaur.com%2Finsomnia.json)
+ [![Run in Insomnia](https://insomnia.rest/images/run.svg)](https://insomnia.rest/run/?label=Mailosaur&uri=https%3A%2F%2Fmailosaur.com%2Finsomnia.json)
 
 ## Creating an account
 
@@ -108,7 +108,7 @@ In automated tests you will want to wait for a new email to arrive. This library
 ```js
 (async () => {
   const MailosaurClient = require('mailosaur')
-  const mailosaur = new MailosaurClient('API_KEY')
+  const mailosaur = new MailosaurClient()
 
   // See https://mailosaur.com/app/project/api
   const serverId = 'abc123'
@@ -126,13 +126,13 @@ In automated tests you will want to wait for a new email to arrive. This library
 
 ### What is this code doing?
 
-1. Sets up an instance of `MailosaurClient` with your API key.
+1. Sets up an instance of `MailosaurClient`, reading the API key from the `MAILOSAUR_API_KEY` environment variable.
 2. Waits for an email to arrive at the server with ID `abc123`.
 3. Outputs the subject line of the email.
 
 ### My email wasn't found
 
-First, check that the email you sent is visible in the [Mailosaur Dashboard](https://mailosaur.com/api/project/messages). 
+First, check that the email you sent is visible in the [Mailosaur Dashboard](https://mailosaur.com/app/project/messages).
 
 If it is, the likely reason is that by default, `messages.get` only searches emails received by Mailosaur in the last 1 hour. You can override this behavior (see the `receivedAfter` option below), however we only recommend doing this during setup, as your tests will generally run faster with the default settings:
 
@@ -141,7 +141,7 @@ const email = await mailosaur.messages.get(
   serverId,
   searchCriteria,
   // Override receivedAfter to search all messages since Jan 1st
-  { receivedAfter: new Date(2021, 01, 01) }
+  { receivedAfter: new Date(2021, 0, 1) }
 )
 ```
 
@@ -154,7 +154,7 @@ If your account has [SMS testing](https://mailosaur.com/sms-testing/) enabled, y
 ```js
 (async () => {
   const MailosaurClient = require('mailosaur')
-  const mailosaur = new MailosaurClient('API_KEY')
+  const mailosaur = new MailosaurClient()
 
   const serverId = 'abc123'
 
@@ -207,7 +207,7 @@ console.log(message.html.body) // "<html><head ..."
 
 ### Working with HTML using JSDOM
 
-If you need to traverse the HTML content of an email. For example, finding an element via a CSS selector, you can use the [JSDOM](https://github.com/jsdom/jsdom) library.
+If you need to traverse the HTML content of an email — for example, finding an element via a CSS selector — you can use the [JSDOM](https://github.com/jsdom/jsdom) library.
 
 ```sh
 npm i -D jsdom
@@ -243,7 +243,7 @@ console.log(firstLink.text) // "Google Search"
 console.log(firstLink.href) // "https://www.google.com/"
 ```
 
-**Important:** To ensure you always have valid emails. Mailosaur only extracts links that have been correctly marked up with `<a>` or `<area>` tags.
+**Important:** To ensure you always have valid emails, Mailosaur only extracts links that have been correctly marked up with `<a>` or `<area>` tags.
 
 ### Links in plain text (including SMS messages)
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Create a [free trial account](https://mailosaur.com/app/signup) for Mailosaur vi
 
 Once you have this, navigate to the [API tab](https://mailosaur.com/app/project/api) to find the following values:
 
-- **Server ID** - Servers act like projects, which group your tests together. You need this ID whenever you interact with a server via the API.
-- **Server Domain** - Every server has its own domain name. You'll need this to send email to your server.
-- **API Key** - You can create an API key per server (recommended), or an account-level API key to use across your whole account. [Learn more about API keys](https://mailosaur.com/docs/managing-your-account/api-keys/).
+- **Server ID** - Inboxes (servers) act like projects, which group your tests together. You need this ID whenever you interact with an inbox (server) via the API.
+- **Server Domain** - Every inbox (server) has its own domain name. You'll need this to send email to your inbox (server).
+- **API Key** - You can create an API key per inbox (server) — recommended — or an account-level API key to use across your whole account. [Learn more about API keys](https://mailosaur.com/docs/managing-your-account/api-keys/).
 
 ## Test email addresses with Mailosaur
 
@@ -91,13 +91,13 @@ Mailosaur gives you an **unlimited number of test email addresses** - with no se
 
 Here's how it works:
 
-* When you create an account, you are given a server.
-* Every server has its own **Server Domain** name (e.g. `abc123.mailosaur.net`)
+* When you create an account, you are given an inbox (server).
+* Every inbox (server) has its own **Server Domain** name (e.g. `abc123.mailosaur.net`)
 * Any email address that ends with `@{YOUR_SERVER_DOMAIN}` will work with Mailosaur without any special setup. For example:
   * `build-423@abc123.mailosaur.net`
   * `john.smith@abc123.mailosaur.net`
   * `rAnDoM63423@abc123.mailosaur.net`
-* You can create more servers when you need them. Each one will have its own domain name.
+* You can create more inboxes (servers) when you need them. Each one will have its own domain name.
 
 ***Can't use test email addresses?** You can also [use SMTP to test email](https://mailosaur.com/docs/email-testing/sending-to-mailosaur/#sending-via-smtp). By connecting your product or website to Mailosaur via SMTP, Mailosaur will catch all email your application sends, regardless of the email address.*
 
@@ -127,7 +127,7 @@ In automated tests you will want to wait for a new email to arrive. This library
 ### What is this code doing?
 
 1. Sets up an instance of `MailosaurClient`, reading the API key from the `MAILOSAUR_API_KEY` environment variable.
-2. Waits for an email to arrive at the server with ID `abc123`.
+2. Waits for an email to arrive at the inbox (server) with ID `abc123`.
 3. Outputs the subject line of the email.
 
 ### My email wasn't found

--- a/README.md
+++ b/README.md
@@ -182,20 +182,15 @@ if (message.text.body.indexOf('Jason') > -1) {
 
 ### Extracting verification codes from plain text
 
-You may have an email or SMS message that contains an account verification code, or some other one-time passcode. You can extract content like this using a simple regex.
-
-Here is how to extract a 6-digit numeric code:
+You may have an email or SMS message that contains an account verification code, or some other one-time passcode. Mailosaur automatically extracts these for you and makes them available via the `codes` array on the message content:
 
 ```js
 console.log(message.text.body) // "Your access code is 243546."
 
-const regEx = new RegExp('([0-9]{6})')
-const matches = regEx.exec(message.text.body)
-
-console.log(matches[0]) // "243546"
+console.log(message.text.codes[0].value) // "243546"
 ```
 
-[Read more](https://mailosaur.com/docs/test-cases/text-content/)
+[Read more](https://mailosaur.com/docs/automation/codes)
 
 ## Testing HTML content
 

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ This library is powered by the Mailosaur [email & SMS testing API](https://mailo
 
 Create a [free trial account](https://mailosaur.com/app/signup) for Mailosaur via the website.
 
-Once you have this, navigate to the [API tab](https://mailosaur.com/app/project/api) to find the following values:
+To start testing you'll need three things:
 
-- **Server ID** - Inboxes (servers) act like projects, which group your tests together. You need this ID whenever you interact with an inbox (server) via the API.
-- **Server Domain** - Every inbox (server) has its own domain name. You'll need this to send email to your inbox (server).
-- **API Key** - You can create an API key per inbox (server) — recommended — or an account-level API key to use across your whole account. [Learn more about API keys](https://mailosaur.com/docs/managing-your-account/api-keys/).
+- **API key** - [manage API keys within the Mailosaur Dashboard](https://mailosaur.com/app/keys). You can scope a key to a single inbox (server) — recommended — or create an account-level key. [Learn more about API keys](https://mailosaur.com/docs/managing-your-account/api-keys/).
+- **Inbox (server) domain** - open [your inbox](https://mailosaur.com/app/servers/default) (server) within the Mailosaur Dashboard to see its domain name (e.g. `abc123.mailosaur.net`). You'll need this to send email to the inbox (server).
+- **Inbox (server) ID** - the first part of the inbox (server) domain. For `abc123.mailosaur.net` the ID is `abc123`. You need this whenever you interact with the inbox (server) via the API.
 
 ## Test email addresses with Mailosaur
 
@@ -92,7 +92,7 @@ Mailosaur gives you an **unlimited number of test email addresses** - with no se
 Here's how it works:
 
 * When you create an account, you are given an inbox (server).
-* Every inbox (server) has its own **Server Domain** name (e.g. `abc123.mailosaur.net`)
+* Every inbox (server) has its own domain name (e.g. `abc123.mailosaur.net`)
 * Any email address that ends with `@{YOUR_SERVER_DOMAIN}` will work with Mailosaur without any special setup. For example:
   * `build-423@abc123.mailosaur.net`
   * `john.smith@abc123.mailosaur.net`
@@ -110,7 +110,6 @@ In automated tests you will want to wait for a new email to arrive. This library
   const MailosaurClient = require('mailosaur')
   const mailosaur = new MailosaurClient()
 
-  // See https://mailosaur.com/app/project/api
   const serverId = 'abc123'
   const serverDomain = 'abc123.mailosaur.net'
 


### PR DESCRIPTION
## Summary

- README content improvements and clearer structure, including better documentation of message `codes`.
- Adopt **inbox (server)** terminology throughout the prose: lead with the product UI term "inbox" and gloss "(server)", so the documentation matches what users see in the dashboard.
- Update dashboard links for the new layout: API keys are managed at `/app/keys`, and an inbox's (server's) domain — from which the ID is derived — is read from the inbox (server) itself at `/app/servers`. The obsolete combined "API tab" (`/app/project/api`) is removed.

## Scope

- Documentation only — no code, public API, or behaviour changes.
- Code identifiers and the `MAILOSAUR_SERVER` environment variable are unchanged.
